### PR TITLE
Upgrade ios plugin signature. Needed for cordova 3.x compatibility

### DIFF
--- a/src/ios/ContactChooser.h
+++ b/src/ios/ContactChooser.h
@@ -7,6 +7,6 @@
 
 @property(strong) NSString* callbackID;
 
-- (void) chooseContact:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) chooseContact:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/ContactChooser.m
+++ b/src/ios/ContactChooser.m
@@ -4,9 +4,8 @@
 @implementation ContactChooser
 @synthesize callbackID;
 
-- (void) chooseContact:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options{
-    self.callbackID = [arguments objectAtIndex:0];
-    
+- (void) chooseContact:(CDVInvokedUrlCommand*)command{
+    self.callbackID = command.callbackId;
     ABPeoplePickerNavigationController *picker = [[ABPeoplePickerNavigationController alloc] init];
     picker.peoplePickerDelegate = self;
     [self.viewController presentModalViewController:picker animated:YES];


### PR DESCRIPTION
Hi,

having almost zero knowledge about iOS Development I changed the method signature for the ContactChoosers plugin method following this upgrade path:

https://github.com/shazron/phonegap-questions/issues/13

After that the plugin does function as before.

All the best,
fkfhain
