### PR TITLE
Cordova 3.x and command-line tooling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# ContactChooser plugin for Cordova / PhoneGap
+# ContactChooser plugin for Cordova 3.x
 
-This Plugin brings up a native iOS or Android contact-picker overlay, accessing the addressbook and returning the selected contact's name and email.
+This plugin brings up a native iOS or Android contact-picker overlay, accessing the addressbook and returning the selected contact's name and email.
 
 ## Usage
 
 Example Usage
 
 ```js
-window.plugins.ContactChooser.chooseContact(function(contactInfo) {
-    alert(contactInfo.displayName + " " + contactInfo.email);
+window.plugins.ContactChooser.chooseContact(function (contactInfo) {
+    setTimeout(function () { // use timeout to fix iOS alert problem
+        alert(contactInfo.displayName + " " + contactInfo.email);
+    }, 0);
 });
 ```
 
@@ -23,63 +25,13 @@ The method which will return a JSON. Example:
 
 ## Requirements
 
-This has been successfully tested from Cordova 2.2.0 through to version 2.7.0.
+This has been successfully tested for the latest version of Cordova (3.1.0).
 
-## iOS
+You're using prior versions of Cordova? Check out our cordova-2.x branch.
 
-### Cordova 2.5.0 - 2.7.0
-In Cordova 2.5.0 the `config.xml` root element has changed to `<widget>`.
+## Installation Instructions
 
-### Cordova 2.3.0 / 2.4.0
-In Cordova 2.3.0 the format of the configuration has changed. The `.plist` based config has been dropped in favour of an XML file `config.xml`. The plugin has to be added to the `<plugins>` section of this file:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<cordova>
-    ...
-	<plugins>
-    	...
-	    <plugin name="ContactChooser" value="ContactChooser"/>
-		...
-    </plugins>
-	...
-</cordova>
-```
-
-### Cordova 2.2.0
-
-Cordova 2.2.0 still uses the `Cordova.plist` configuration und thus the plugin has to be added as key value pair in the Plugins section of that file with key `ContactChooser` and value `ContactChooser`.
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	... 
-	<key>Plugins</key>
-	<dict>
-		...
-		<key>ContactChooser</key>
-		<string>ContactChooser</string>
-	</dict>
-</dict>
-</plist>
-```
-
-## Android
-
-First you should maybe customize the package in `ContactChooserPlugin.java`. The plugin has to be registered in the Cordova `config.xml` in the `<plugins>` section, make sure to get the package right:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<cordova>
-    ...
-    <plugins>
-        ...
-        <plugin name="ContactChooser" value="com.mypackage.name.ContactChooserPlugin" />
-    </plugins>
-</cordova>
-```
+The ContactChooser plugin provides support for Cordova's command-line tooling.
 
 ## MIT Licence
 

--- a/example/index.html
+++ b/example/index.html
@@ -18,7 +18,9 @@
         <script>
             function alertContact() {
                 window.plugins.ContactChooser.chooseContact(function(contactInfo) {
-                    alert(contactInfo.displayName + " " + contactInfo.email);
+                    setTimeout(function() { // use timeout to fix iOS alert problem
+                        alert(contactInfo.displayName + " " + contactInfo.email);
+                    }, 0);
                 });
             }
         </script>

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="format-detection" content="telephone=no" />
+        <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, target-densitydpi=device-dpi" />
+        <title>Monday ContactChooser</title>
+    </head>
+    <body>
+        <div>
+            <h1>Monday ContactChooser</h1>
+            <div>
+                <button onclick="alertContact()">Get Contact</button>
+            </div>
+        </div>
+        <script type="text/javascript" src="cordova.js"></script>
+        <script type="text/javascript" src="ContactChooser.js"></script>
+        <script>
+            function alertContact() {
+                window.plugins.ContactChooser.chooseContact(function(contactInfo) {
+                    alert(contactInfo.displayName + " " + contactInfo.email);
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        id="com.monday.contact-chooser"
+        version="0.2">
+
+    <name>Contact Chooser</name>
+    <description>Native contact-picker overlay, accessing the address book</description>
+    <license>MIT Licence</license>
+    <keywords>cordova,addressbook,contacts</keywords>
+
+    <js-module src="www/ContactChooser.js" name="ContactChooser">
+        <clobbers target="ContactChooser" />
+    </js-module>
+
+    <!-- android -->
+    <platform name="android">
+
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="ContactChooser">
+                <param name="android-package" value="com.monday.cordova.ContactChooserPlugin"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/ContactChooserPlugin.java" target-dir="src/com/monday/cordova" />
+
+    </platform>
+
+    <!-- ios -->
+    <platform name="ios">
+
+        <config-file target="config.xml" parent="/*">
+            <feature name="ContactChooser">
+                <param name="ios-package" value="ContactChooser"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/ContactChooser.h" />
+        <source-file src="src/ios/ContactChooser.m" />
+
+        <framework src="AddressBook.framework" />
+        <framework src="AddressBookUI.framework" />
+
+    </platform>
+
+</plugin>

--- a/src/android/ContactChooserPlugin.java
+++ b/src/android/ContactChooserPlugin.java
@@ -1,4 +1,4 @@
-package com.mypackage.name;
+package com.monday.cordova;
 
 import android.app.Activity;
 import android.content.Context;
@@ -6,9 +6,9 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.ContactsContract;
-import org.apache.cordova.api.CallbackContext;
-import org.apache.cordova.api.CordovaPlugin;
-import org.apache.cordova.api.PluginResult;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/src/ios/ContactChooser.h
+++ b/src/ios/ContactChooser.h
@@ -7,6 +7,6 @@
 
 @property(strong) NSString* callbackID;
 
-- (void) chooseContact:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) chooseContact:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/ContactChooser.m
+++ b/src/ios/ContactChooser.m
@@ -4,8 +4,8 @@
 @implementation ContactChooser
 @synthesize callbackID;
 
-- (void) chooseContact:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options{
-    self.callbackID = [arguments objectAtIndex:0];
+- (void) chooseContact:(CDVInvokedUrlCommand*)command{
+    self.callbackID = command.callbackId;
     
     ABPeoplePickerNavigationController *picker = [[ABPeoplePickerNavigationController alloc] init];
     picker.peoplePickerDelegate = self;
@@ -21,8 +21,8 @@
     {
         ABMultiValueRef multi = ABRecordCopyValue(person, kABPersonEmailProperty);
         int index = ABMultiValueGetIndexForIdentifier(multi, identifier);
-        NSString *email = (NSString *)ABMultiValueCopyValueAtIndex(multi, index);
-        NSString *displayName = (NSString *)ABRecordCopyCompositeName(person);
+        NSString *email = (__bridge NSString *)ABMultiValueCopyValueAtIndex(multi, index);
+        NSString *displayName = (__bridge NSString *)ABRecordCopyCompositeName(person);
 
         NSMutableDictionary* contact = [NSMutableDictionary dictionaryWithCapacity:2];
         [contact setObject:email forKey: @"email"];


### PR DESCRIPTION
Updates the ContactChooser plugin to be compatible with the new plugin architecture of Cordova 3.0 and higher.
Also adds support for the command-line tooling by adding a plugin description file.
