### PR TITLE
Add read contacts permission for android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,10 @@
             </feature>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.READ_CONTACTS" />
+        </config-file>
+
         <source-file src="src/android/ContactChooserPlugin.java" target-dir="src/com/monday/cordova" />
 
     </platform>


### PR DESCRIPTION
When I used this on Android I realized that it didn't have the needed permissions, so I added it to the plugin.xml file.
