### PR TITLE
android picker - filter only contacts with phone numbers

### DIFF
--- a/src/android/ContactChooserPlugin.java
+++ b/src/android/ContactChooserPlugin.java
@@ -27,8 +27,9 @@ public class ContactChooserPlugin extends CordovaPlugin {
 
 		if (action.equals("chooseContact")) {
 
-            Intent intent = new Intent(Intent.ACTION_PICK,
-                    ContactsContract.CommonDataKinds.Email.CONTENT_URI);
+            Intent intent = new Intent(Intent.ACTION_PICK, Uri.parse("content://contacts"));
+            intent.setType(ContactsContract.CommonDataKinds.Phone.CONTENT_TYPE);
+
             cordova.startActivityForResult(this, intent, CHOOSE_CONTACT);
 
             PluginResult r = new PluginResult(PluginResult.Status.NO_RESULT);


### PR DESCRIPTION
Android fix/feature

When picking contact there is a large list of mail-only contacts. this creates a noise for picking a numeric contact

This PR filter contacts with a phone number
code is from here: http://stackoverflow.com/a/27647590/3191896
